### PR TITLE
Uvar error fix

### DIFF
--- a/collections/npc/add.alias
+++ b/collections/npc/add.alias
@@ -2,7 +2,7 @@ embed <drac2>
 
 # getting all the relevant variables
 c = ctx.channel.id
-u = load_json(get('NPCS'))
+u = load_json(get('NPCS', '{}'))
 args = argparse(&ARGS&)
 name = args.last('name')
 url = args.last('url')


### PR DESCRIPTION
This change allows the NPC uvar to be added without having to do it manually. If a user were to run this command without establishing the uvar, then an error would pop up.